### PR TITLE
Ignore dovecot warnings

### DIFF
--- a/ignore.d.server/x-dovecot
+++ b/ignore.d.server/x-dovecot
@@ -18,3 +18,5 @@
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ dovecot: imap\([[:alnum:]]+\): Logged out
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ dovecot: (lmtp|pop3|imap)(-login)?(\([-_.@[:alnum:]]+\))?: (Connection closed|Disconnected)
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ auth: pam_unix
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ dovecot: auth: Warning: auth client 0 disconnected with 1 pending requests: Connection reset by peer$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ dovecot: auth: Warning: auth client 0 disconnected with 1 pending requests: EOF$


### PR DESCRIPTION
@bwesterb 

I have observed two warnings in my logs recently. According to https://serverfault.com/questions/661826/postfix-dovecot-sasl-login-authentication-aborted they seem to be harmless.